### PR TITLE
fix the error with using floating indices

### DIFF
--- a/openpiv/examples/test_widim/test_widim.py
+++ b/openpiv/examples/test_widim/test_widim.py
@@ -1,5 +1,5 @@
 import numpy as np
-import openpiv
+import openpiv.process
 from openpiv.tools import imread
 
 
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     frame_a = np.uint32(imread('exp1_001_a.bmp'))
     frame_b = np.uint32(imread('exp1_001_b.bmp'))
     x,y,u,v, mask = openpiv.process.WiDIM( frame_a.astype(np.int32), 
-    frame_b.astype(np.int32),  ones_like(frame_a).astype(np.int32), 
+    frame_b.astype(np.int32),  np.ones_like(frame_a).astype(np.int32), 
     min_window_size=32, overlap_ratio=0.25, coarse_factor=2, dt=0.02, 
     validation_method='mean_velocity', trust_1st_iter=1, validation_iter=2, 
     tolerance=0.7, nb_iter_max=4, sig2noise_method='peak2peak')

--- a/openpiv/examples/test_widim/test_widim.py
+++ b/openpiv/examples/test_widim/test_widim.py
@@ -1,0 +1,14 @@
+import numpy as np
+import openpiv
+from openpiv.tools import imread
+
+
+
+if __name__ == "__main__":
+    frame_a = np.uint32(imread('exp1_001_a.bmp'))
+    frame_b = np.uint32(imread('exp1_001_b.bmp'))
+    x,y,u,v, mask = openpiv.process.WiDIM( frame_a.astype(np.int32), 
+    frame_b.astype(np.int32),  ones_like(frame_a).astype(np.int32), 
+    min_window_size=32, overlap_ratio=0.25, coarse_factor=2, dt=0.02, 
+    validation_method='mean_velocity', trust_1st_iter=1, validation_iter=2, 
+    tolerance=0.7, nb_iter_max=4, sig2noise_method='peak2peak')

--- a/openpiv/src/process.pyx
+++ b/openpiv/src/process.pyx
@@ -815,8 +815,8 @@ def WiDIM( np.ndarray[DTYPEi_t, ndim=2] frame_a,
                 #fill windows a and b
                 for L in range(W[K]):
                     for M in range(W[K]):
-                        window_a[L,M] = frame_a[F[K,I,J,0] - W[K]/2 + L, F[K,I,J,1] - W[K]/2 + M]
-                        window_b[L,M] = frame_b[F[K,I,J,2] - W[K]/2 + L, F[K,I,J,3] - W[K]/2 + M]
+                        window_a[L,M] = frame_a[int(F[K,I,J,0] - W[K]/2 + L), int(F[K,I,J,1] - W[K]/2 + M)]
+                        window_b[L,M] = frame_b[int(F[K,I,J,2] - W[K]/2 + L), int(F[K,I,J,3] - W[K]/2 + M)]
                         
                 #perform correlation of the two windows
                 corr = correlate_windows( window_b, window_a, nfftx=nfftx, nffty=nffty )
@@ -825,7 +825,7 @@ def WiDIM( np.ndarray[DTYPEi_t, ndim=2] frame_a,
                 i_peak, j_peak = c.subpixel_peak_position( subpixel_method )#get peak position
 
                 #prevent 'Not a Number' peak location
-                if np.any(np.isnan((i_peak, j_peak))) or mark[F[K,I,J,0], F[K,I,J,1]] == 0:
+                if np.any(np.isnan((i_peak, j_peak))) or mark[int(F[K,I,J,0]), int(F[K,I,J,1])] == 0:
                     F[K,I,J,8] = 0.0
                     F[K,I,J,9] = 0.0
                 else:
@@ -892,7 +892,7 @@ def WiDIM( np.ndarray[DTYPEi_t, ndim=2] frame_a,
                         
                         
                         # If there are neighbours present and no mask, validate the velocity
-                        if np.sum(neighbours_present) !=0 and mark[F[K,I,J,0], F[K,I,J,1]] == 1:
+                        if np.sum(neighbours_present) !=0 and mark[int(F[K,I,J,0]), int(F[K,I,J,1])] == 1:
                         #if np.sum(neighbours_present):
 
                             #computing the mean velocity


### PR DESCRIPTION
https://stackoverflow.com/questions/8514547/why-ndarray-allow-floating-point-index/43305317#43305317 

Using a floating point index in an ndarray is no longer allowed and raises an error as of version 1.12.

```
IndexError: only integers, slices (`:`), ellipsis (`...`),
    numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```
Indexing with floats will raise IndexError, e.g., a[0, 0.0]. (See 1.11 release notes)

Indexing with floats raises IndexError, e.g., a[0, 0.0]. (See **1.12** release notes)